### PR TITLE
Init wb.tests in tests if missing

### DIFF
--- a/tests/datamodel.Entity.tests.js
+++ b/tests/datamodel.Entity.tests.js
@@ -259,6 +259,7 @@
 		};
 	}
 
+	wb.tests = wb.tests || {};
 	wb.tests.testEntity = function( testDefinition ) {
 		var test = new EntityTest( testDefinition );
 


### PR DESCRIPTION
wb.tests is initialized by wikibase.tests, which loads most QUnit tests of
WikibaseLib. We don't need anything from wb.tests, we just need to set a
property on it.

Another option would be to move this to wikibase.datamodel.tests, a namespace we can freely control in this module.
