### PR TITLE
Manually require init.php in init.mw.php

### DIFF
--- a/init.mw.php
+++ b/init.mw.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once 'init.php';
 $GLOBALS['wgExtensionCredits']['wikibase'][] = array(
 	'path' => __FILE__,
 	'name' => 'Wikibase DataModel JavaScript',


### PR DESCRIPTION
I have no idea why this is being loaded (by composer?) without
setting the version constant (which is defined in init.php) first.
But this is causing PHP notices for me on Special:Version
