### PR TITLE
Simplify remoteExtPath regex

### DIFF
--- a/resources.php
+++ b/resources.php
@@ -10,16 +10,12 @@
 return call_user_func( function() {
 	global $wgResourceModules;
 
-	preg_match(
-		'+^(.*?)(' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__ . DIRECTORY_SEPARATOR . 'src',
-		'remoteExtPath' => '..' . $remoteExtPathParts[2] . DIRECTORY_SEPARATOR . 'src',
+		'remoteExtPath' => '..' . $remoteExtPath[0] . DIRECTORY_SEPARATOR . 'src',
 	);
 
 	$modules = array(

--- a/resources.test.php
+++ b/resources.test.php
@@ -3,16 +3,12 @@
 global $wgHooks;
 
 $wgHooks['ResourceLoaderTestModules'][] = function( array &$testModules, \ResourceLoader &$resourceLoader ) {
-	preg_match(
-		'+^(.*?)(' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)' .
-			preg_quote( DIRECTORY_SEPARATOR ) . '.*)$+',
-		__DIR__,
-		$remoteExtPathParts
-	);
+	preg_match( '+' . preg_quote( DIRECTORY_SEPARATOR ) . '(?:vendor|extensions)'
+		. preg_quote( DIRECTORY_SEPARATOR ) . '.*+', __DIR__, $remoteExtPath );
 
 	$moduleTemplate = array(
 		'localBasePath' => __DIR__ . DIRECTORY_SEPARATOR . 'tests',
-		'remoteExtPath' => '..' . $remoteExtPathParts[2] . DIRECTORY_SEPARATOR . 'tests',
+		'remoteExtPath' => '..' . $remoteExtPath[0] . DIRECTORY_SEPARATOR . 'tests',
 	);
 
 	$modules = array(


### PR DESCRIPTION
The complexity of this regular expression is just not needed. Just search for the first occurrence of `/vendor/` or `/extensions/` and match everything from there, that's it. Using a regex character (`+`) as delimiter does have the advantage that it must not be repeated when calling `preg_quote`, it's always quoted.