### PR TITLE
Remove mw.ext.dataValues

### DIFF
--- a/resources.php
+++ b/resources.php
@@ -121,7 +121,7 @@ return call_user_func( function() {
 				'EntityId.js',
 			),
 			'dependencies' => array(
-				'mw.ext.dataValues',
+				'dataValues.DataValue',
 				'util.inherit',
 				'wikibase.datamodel.__namespace',
 			),
@@ -252,7 +252,7 @@ return call_user_func( function() {
 				'PropertyValueSnak.js',
 			),
 			'dependencies' => array(
-				'mw.ext.dataValues',
+				'dataValues.DataValue',
 				'util.inherit',
 				'wikibase.datamodel.__namespace',
 				'wikibase.datamodel.Snak',

--- a/resources.test.php
+++ b/resources.test.php
@@ -224,7 +224,7 @@ $wgHooks['ResourceLoaderTestModules'][] = function( array &$testModules, \Resour
 				'Snak.tests.js',
 			),
 			'dependencies' => array(
-				'mw.ext.dataValues',
+				'dataValues.values',
 				'wikibase.datamodel.PropertyNoValueSnak',
 				'wikibase.datamodel.PropertySomeValueSnak',
 				'wikibase.datamodel.PropertyValueSnak',
@@ -237,7 +237,7 @@ $wgHooks['ResourceLoaderTestModules'][] = function( array &$testModules, \Resour
 				'SnakList.tests.js',
 			),
 			'dependencies' => array(
-				'mw.ext.dataValues',
+				'dataValues.values',
 				'wikibase.datamodel.PropertyNoValueSnak',
 				'wikibase.datamodel.PropertySomeValueSnak',
 				'wikibase.datamodel.PropertyValueSnak',


### PR DESCRIPTION
`mw.ext.dataValues` doesn't exist any more in https://github.com/wmde/DataValuesJavascript 0.7. But as far as I can see this component here already doesn't use it any more. So the dependency is just wrong and can be simplified without touching any version numbers. Am I right?