### PR TITLE
Add function names to JavaScript closures

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -16,7 +16,7 @@
  * @throws {Error} if item constructor is not a Function.
  * @throws {Error} if item constructor prototype does not feature an equals() function.
  */
-var SELF = wb.datamodel.Map = function( ItemConstructor, map ) {
+var SELF = wb.datamodel.Map = function WbDataModelMap( ItemConstructor, map ) {
 	map = map || {};
 
 	if( !$.isFunction( ItemConstructor ) ) {


### PR DESCRIPTION
These function names are not meant to be used, they make debugging easier because the debugger can then show the function name.