### PR TITLE
Fix broken JSHint dependency

### DIFF
--- a/build/travis/script.sh
+++ b/build/travis/script.sh
@@ -3,7 +3,7 @@
 set -x
 
 if [[ $RUNJOB == jshint ]]; then
-	npm install jshint
+	npm install jshint@~2.8
 	jshint src/ tests/
 	exit $?
 fi


### PR DESCRIPTION
JSHint 2.9 is broken and should and can not be used. Our tests fail with this version.