### PR TITLE
Don't allow Terms and MultiTerms with empty language code

### DIFF
--- a/src/MultiTerm.js
+++ b/src/MultiTerm.js
@@ -41,11 +41,11 @@ $.extend( SELF.prototype, {
 	/**
 	 * @param {string} languageCode
 	 *
-	 * @throws {Error} when the language code is not a string.
+	 * @throws {Error} when the language code is not a string or empty.
 	 */
 	setLanguageCode: function( languageCode ) {
-		if( typeof languageCode !== 'string' ) {
-			throw new Error( 'Language code has to be a string' );
+		if( typeof languageCode !== 'string' || languageCode === '' ) {
+			throw new Error( 'Language code has to be a non-empty string' );
 		}
 		this._languageCode = languageCode;
 	},

--- a/src/Term.js
+++ b/src/Term.js
@@ -41,11 +41,11 @@ $.extend( SELF.prototype, {
 	/**
 	 * @param {string} languageCode
 	 *
-	 * @throws {Error} if language code is not a string.
+	 * @throws {Error} if language code is not a string or empty.
 	 */
 	setLanguageCode: function( languageCode ) {
-		if( typeof languageCode !== 'string' ) {
-			throw new Error( 'Language code has to be a string' );
+		if( typeof languageCode !== 'string' || languageCode === '' ) {
+			throw new Error( 'Language code has to be a non-empty string' );
 		}
 		this._languageCode = languageCode;
 	},

--- a/tests/MultiTerm.tests.js
+++ b/tests/MultiTerm.tests.js
@@ -30,7 +30,8 @@ QUnit.test( 'Constructor (negative)', function( assert ) {
 		[undefined, []],
 		['', undefined],
 		['de', 1],
-		[1, '']
+		[1, ''],
+		['', []]
 	];
 
 	/**

--- a/tests/Term.tests.js
+++ b/tests/Term.tests.js
@@ -16,7 +16,8 @@ var testSets = {
 		[undefined, ''],
 		['', undefined],
 		['de', 1],
-		[1, '']
+		[1, ''],
+		['', 'foo']
 	]
 };
 


### PR DESCRIPTION
This makes the JavaScript data model more secure against invalid state and
matches the behaviour of the PHP data model.