### PR TITLE
Add missing param doc to Claim/StatementGroup

### DIFF
--- a/src/ClaimGroup.js
+++ b/src/ClaimGroup.js
@@ -13,10 +13,15 @@ var PARENT = wb.datamodel.Group;
  *
  * @constructor
  *
+ * @param {string} propertyId
  * @param {wikibase.datamodel.ClaimList} [claimList=new wikibase.datamodel.ClaimList()]
  */
-wb.datamodel.ClaimGroup = util.inherit( 'wbClaimGroup', PARENT, function( propertyId, claimList ) {
-	PARENT.call( this, propertyId, wb.datamodel.ClaimList, 'getPropertyIds', claimList );
-} );
+wb.datamodel.ClaimGroup = util.inherit(
+	'wbClaimGroup',
+	PARENT,
+	function WbDataModelClaimGroup( propertyId, claimList ) {
+		PARENT.call( this, propertyId, wb.datamodel.ClaimList, 'getPropertyIds', claimList );
+	}
+);
 
 }( wikibase ) );

--- a/src/StatementGroup.js
+++ b/src/StatementGroup.js
@@ -13,12 +13,13 @@ var PARENT = wb.datamodel.Group;
  *
  * @constructor
  *
+ * @param {string} propertyId
  * @param {wikibase.datamodel.StatementList} [statementList=new wikibase.datamodel.StatementList()]
  */
 wb.datamodel.StatementGroup = util.inherit(
 	'WbDataModelStatementGroup',
 	PARENT,
-	function( propertyId, statementList ) {
+	function WbDataModelStatementGroup( propertyId, statementList ) {
 		PARENT.call( this, propertyId, wb.datamodel.StatementList, 'getPropertyIds', statementList );
 	}
 );


### PR DESCRIPTION
This patch also names the constructor functions. This is for more readable stack traces.