### PR TITLE
Do not clone during Group.equals

### DIFF
--- a/src/Group.js
+++ b/src/Group.js
@@ -162,7 +162,7 @@ $.extend( SELF.prototype, {
 		return group === this
 			|| group instanceof SELF
 				&& this._key === group.getKey()
-				&& this._groupableCollection.equals( group.getItemContainer() );
+				&& this._groupableCollection.equals( group._groupableCollection );
 	}
 
 } );


### PR DESCRIPTION
I consider this an actual bug. The function creates a clone. But this is not necessary for a straight equals check. We are allowed to use the private property because we are inside the class.