### PR TITLE
Remove unused filtering from getQualifiers

### DIFF
--- a/src/Claim.js
+++ b/src/Claim.js
@@ -76,20 +76,8 @@ $.extend( SELF.prototype, {
 	/**
 	 * @return {wikibase.datamodel.SnakList}
 	 */
-	getQualifiers: function( propertyId ) {
-		if( !propertyId ) {
-			return this._qualifiers;
-		}
-
-		var filteredQualifiers = new wb.datamodel.SnakList();
-
-		this._qualifiers.each( function( i, snak ) {
-			if( snak.getPropertyId() === propertyId ) {
-				filteredQualifiers.addItem( snak );
-			}
-		} );
-
-		return filteredQualifiers;
+	getQualifiers: function() {
+		return this._qualifiers;
 	},
 
 	/**

--- a/src/SnakList.js
+++ b/src/SnakList.js
@@ -20,26 +20,25 @@ wb.datamodel.SnakList = util.inherit( 'WbDataModelSnakList', PARENT, function( s
 	PARENT.call( this, wikibase.datamodel.Snak, snaks );
 }, {
 	/**
-	 * Returns a SnakList with the snaks featuring a specific property id. If the property id
-	 * parameter is omitted, a copy of the whole SnakList object is returned.
+	 * Returns a SnakList with the snaks featuring a specific property id.
 	 *
-	 * @param {string|null} [propertyId=null]
+	 * @param {string} propertyId
 	 * @return {wikibase.datamodel.SnakList}
 	 */
 	getFilteredSnakList: function( propertyId ) {
 		if( !propertyId ) {
-			return new wb.datamodel.SnakList( $.merge( [], this._items ) );
+			throw new Error( 'Can not filter with no propertyId.' );
 		}
 
-		var filteredQualifiers = new wb.datamodel.SnakList();
+		var filteredSnakList = new wb.datamodel.SnakList();
 
 		this.each( function( i, snak ) {
 			if( snak.getPropertyId() === propertyId ) {
-				filteredQualifiers.addItem( snak );
+				filteredSnakList.addItem( snak );
 			}
 		} );
 
-		return filteredQualifiers;
+		return filteredSnakList;
 	},
 
 	/**

--- a/tests/Claim.tests.js
+++ b/tests/Claim.tests.js
@@ -65,7 +65,7 @@ QUnit.test( 'setMainSnak() & getMainSnak()', function( assert ) {
 } );
 
 QUnit.test( 'setQualifiers() & getQualifiers()', function( assert ) {
-	assert.expect( 2 );
+	assert.expect( 1 );
 	var claim = new wb.datamodel.Claim( new wb.datamodel.PropertyNoValueSnak( 'p1' ) ),
 		qualifiers = new wb.datamodel.SnakList( [
 			new wb.datamodel.PropertyNoValueSnak( 'p10' ),
@@ -75,17 +75,10 @@ QUnit.test( 'setQualifiers() & getQualifiers()', function( assert ) {
 
 	claim.setQualifiers( qualifiers );
 
-	assert.ok(
-		claim.getQualifiers().equals( qualifiers ),
+	assert.strictEqual(
+		claim.getQualifiers(),
+		qualifiers,
 		'Verified qualifiers being set.'
-	);
-
-	assert.ok(
-		claim.getQualifiers( 'p10' ).equals( new wb.datamodel.SnakList( [
-			new wb.datamodel.PropertyNoValueSnak( 'p10' ),
-			new wb.datamodel.PropertySomeValueSnak( 'p10' )
-		] ) ),
-		'Altered qualifiers.'
 	);
 } );
 

--- a/tests/SnakList.tests.js
+++ b/tests/SnakList.tests.js
@@ -61,24 +61,22 @@ QUnit.test( 'Constructor', function( assert ) {
 } );
 
 QUnit.test( 'getFilteredSnakList()', function( assert ) {
-	assert.expect( 16 );
+	assert.expect( 11 );
+	assert.throws(
+		function() {
+			var snakList = new wb.datamodel.SnakList( [] );
+			snakList.getFilteredSnakList();
+		},
+		'getFilteredSnakList() throws an error when called with null.'
+	);
+
 	for( var i = 0; i < testSets.length; i++ ) {
 		var snakList = new wb.datamodel.SnakList( testSets[i] );
-
-		assert.ok(
-			snakList.getFilteredSnakList() instanceof wb.datamodel.SnakList,
-			'Returned SnakList object when issuing getFilteredSnakList() without parameter.'
-		);
 
 		assert.strictEqual(
 			snakList.getFilteredSnakList( 'P9999' ).length,
 			0,
 			'No filtered SnakList returned for an empty SnakList.'
-		);
-
-		assert.ok(
-			snakList.getFilteredSnakList().equals( new wb.datamodel.SnakList( snakList.toArray() ) ),
-			'Returning SnakList clone when issuing getFilteredSnakList() without parameter.'
 		);
 
 		var groupedSnakLists = {},


### PR DESCRIPTION
This gets rid of an other cloning (see #47). But this one is currently not used outside of tests.
* `getFilteredSnakList` should do exactly that and not have a special case when the filter is a falsy value.
* `getQualifiers` should do exactly that and not do optional filtering.

If you want filtering, call `getQualifiers().getFilteredSnakList( propertyId )`.