### PR TITLE
Fix @param type hint in SiteLink.js

### DIFF
--- a/src/SiteLink.js
+++ b/src/SiteLink.js
@@ -11,7 +11,7 @@
  * @constructor
  *
  * @param {string} siteId
- * @param {string} pageName
+ * @param {string|null} pageName
  * @param {string[]} [badges=[]]
  *
  * @throws {Error} if a required parameter is not specified properly.


### PR DESCRIPTION
pageName is allowed to be null when you start editing a new, empty sitelink.