### PR TITLE
Support Set.toArray

### DIFF
--- a/src/Set.js
+++ b/src/Set.js
@@ -91,11 +91,15 @@ var SELF = wb.datamodel.Set = util.inherit(
 
 	/**
 	 * @inheritdoc
-	 *
-	 * @throws {Error} when being called since a set cannot be converted to an array.
 	 */
 	toArray: function() {
-		throw new Error( 'Set cannot be exported to an array' );
+		var items = [];
+
+		for( var key in this._items ) {
+			items.push( this._items[key] );
+		}
+
+		return items;
 	},
 
 	/**

--- a/tests/Set.tests.js
+++ b/tests/Set.tests.js
@@ -388,6 +388,24 @@ QUnit.test( 'equals()', function( assert ) {
 	);
 } );
 
+QUnit.test( 'toArray()', function( assert ) {
+	assert.expect( 2 );
+	var item = getTestItems( 1 )[0],
+		set = createSet( [item] ),
+		actual = set.toArray();
+
+	assert.ok(
+		actual.length === 1 && actual[0] === item,
+		'toArray() returns original items.'
+	);
+
+	assert.notStrictEqual(
+		set.toArray(),
+		actual,
+		'toArray() does clone.'
+	);
+} );
+
 QUnit.test( 'hasItem()', function( assert ) {
 	assert.expect( 3 );
 	var items = getTestItems( 2 ),


### PR DESCRIPTION
There is not really a good reason to not support this. The contrary. We are converting `SiteLinkSet`s to arrays multiple times in our code base. These individual conversions should be replaced with a straight `toArray`.