### PR TITLE
Remove dysfunctional convenience methods from Item/Property

### DIFF
--- a/src/Item.js
+++ b/src/Item.js
@@ -84,20 +84,6 @@ var SELF = wb.datamodel.Item = util.inherit(
 	},
 
 	/**
-	 * @param {wikibase.datamodel.Statement} statement
-	 */
-	addStatement: function( statement ) {
-		this._statementGroupSet.addStatement( statement );
-	},
-
-	/**
-	 * @param {wikibase.datamodel.Statement} statement
-	 */
-	removeStatement: function( statement ) {
-		this._statementGroupSet.removeStatement( statement );
-	},
-
-	/**
 	 * @return {boolean}
 	 */
 	isEmpty: function() {

--- a/src/Property.js
+++ b/src/Property.js
@@ -69,20 +69,6 @@ var SELF = wb.datamodel.Property = util.inherit(
 	},
 
 	/**
-	 * @param {wikibase.datamodel.Statement} statement
-	 */
-	addStatement: function( statement ) {
-		this._statementGroupSet.addStatement( statement );
-	},
-
-	/**
-	 * @param {wikibase.datamodel.Statement} statement
-	 */
-	removeStatement: function( statement ) {
-		this._statementGroupSet.removeStatement( statement );
-	},
-
-	/**
 	 * @return {boolean}
 	 */
 	isEmpty: function() {


### PR DESCRIPTION
`this._statementGroupSet` is, as the name suggests, a `StatementGroupSet`, which is a `Set`. The `Set` class declares both an `isEmpty` and an `equals` method, but there is no `addStatement` or `removeStatement` anywhere in the code base. Not declared, not tested, and not used anywhere.

To add and remove statements code calls `entity.getStatements().addItem( … )` and `removeItem( … )`, both declared on the `Set` class.