### PR TITLE
Remove unused getSortKey feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"data-values/javascript": "~0.8.0|~0.7.0|~0.6.0"
+		"data-values/javascript": "^0.9.0"
 	},
 	"autoload": {
 		"files": [

--- a/src/EntityId.js
+++ b/src/EntityId.js
@@ -64,13 +64,6 @@ wb.datamodel.EntityId = util.inherit(
 	/**
 	 * @inheritdoc
 	 */
-	getSortKey: function() {
-		return this._serialization;
-	},
-
-	/**
-	 * @inheritdoc
-	 */
 	toJSON: function() {
 		return {
 			'id': this._serialization

--- a/tests/EntityId.tests.js
+++ b/tests/EntityId.tests.js
@@ -12,7 +12,7 @@ var testSets = [
 ];
 
 QUnit.test( 'Constructor and getters', function( assert ) {
-	assert.expect( 8 );
+	assert.expect( 6 );
 	for( var i = 0; i < testSets.length; i++ ) {
 		var entityId = new wb.datamodel.EntityId( testSets[i] );
 
@@ -31,11 +31,6 @@ QUnit.test( 'Constructor and getters', function( assert ) {
 			entityId.getValue(),
 			entityId,
 			'Test set #' + i + ': Verified getValue() returning original object.'
-		);
-
-		assert.ok(
-			typeof entityId.getSortKey() === 'string',
-			'Test set #' + i + ': getSortKey() returns a string.'
 		);
 	}
 } );


### PR DESCRIPTION
This depends on https://github.com/wmde/DataValuesJavaScript/pull/115 being merged and released first.

[Bug: T172916](https://phabricator.wikimedia.org/T172916)