### PR TITLE
Add missing class level documentation links

### DIFF
--- a/src/Claim.js
+++ b/src/Claim.js
@@ -21,6 +21,9 @@ var SELF = wb.datamodel.Claim = function WbDataModelClaim( mainSnak, qualifiers,
 	this._guid = guid || null;
 };
 
+/**
+ * @class wikibase.datamodel.Claim
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {wikibase.datamodel.Snak}

--- a/src/Entity.js
+++ b/src/Entity.js
@@ -24,6 +24,9 @@ var SELF = wb.datamodel.Entity = function WbDataModelEntity() {
  */
 SELF.TYPE = null;
 
+/**
+ * @class wikibase.datamodel.Entity
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {string}

--- a/src/Fingerprint.js
+++ b/src/Fingerprint.js
@@ -36,6 +36,9 @@ var SELF
 		this._aliases = aliases;
 	};
 
+/**
+ * @class wikibase.datamodel.Fingerprint
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {wikibase.datamodel.TermMap}

--- a/src/Group.js
+++ b/src/Group.js
@@ -41,6 +41,9 @@ var SELF = wb.datamodel.Group = function WbDataModelGroup(
 	this.setItemContainer( groupableCollection || new GroupableCollectionConstructor() );
 };
 
+/**
+ * @class wikibase.datamodel.Group
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {*}

--- a/src/GroupableCollection.js
+++ b/src/GroupableCollection.js
@@ -13,6 +13,9 @@
  */
 var SELF = wb.datamodel.GroupableCollection = function WbDataModelGroupableCollection() {};
 
+/**
+ * @class wikibase.datamodel.GroupableCollection
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * Returns the collection items as list.

--- a/src/Map.js
+++ b/src/Map.js
@@ -35,6 +35,9 @@ var SELF = wb.datamodel.Map = function WbDataModelMap( ItemConstructor, map ) {
 	}
 };
 
+/**
+ * @class wikibase.datamodel.Map
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {Function}

--- a/src/MultiTerm.js
+++ b/src/MultiTerm.js
@@ -18,6 +18,9 @@ var SELF = wb.datamodel.MultiTerm = function WbDataModelMultiTerm( languageCode,
 	this.setTexts( texts );
 };
 
+/**
+ * @class wikibase.datamodel.MultiTerm
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {string}

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -30,6 +30,9 @@ var SELF = wb.datamodel.Reference = function WbDataModelReference( snaks, hash )
 	this._hash = hash || null;
 };
 
+/**
+ * @class wikibase.datamodel.Reference
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {string|null}

--- a/src/SiteLink.js
+++ b/src/SiteLink.js
@@ -26,6 +26,9 @@ var SELF = wb.datamodel.SiteLink = function WbDataModelSiteLink( siteId, pageNam
 	this._badges = badges || [];
 };
 
+/**
+ * @class wikibase.datamodel.SiteLink
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {string}

--- a/src/Snak.js
+++ b/src/Snak.js
@@ -32,6 +32,9 @@ var SELF = wb.datamodel.Snak = function WbDataModelSnak( propertyId ) {
  */
 SELF.TYPE = null;
 
+/**
+ * @class wikibase.datamodel.Snak
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {string}

--- a/src/Term.js
+++ b/src/Term.js
@@ -18,6 +18,9 @@ var SELF = wb.datamodel.Term = function WbDataModelTerm( languageCode, text ) {
 	this.setText( text );
 };
 
+/**
+ * @class wikibase.datamodel.Term
+ */
 $.extend( SELF.prototype, {
 	/**
 	 * @property {string}


### PR DESCRIPTION
This does make the documentation much stronger. Without this, an IDE has a hard time figuring out that the `$.extends` stuff belongs to the class constructor directly above. With this, my IDE finally understands which properties and methods belong to these classes.

If you merge this, please also merge https://github.com/wmde/DataValuesJavaScript/pull/121.