### PR TITLE
Add hash to Snak

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ at the heart of the [Wikibase software](http://wikiba.se/).
 
 ## Release notes
 
+### 3.1.0 (dev)
+
+* Added a `hash` parameter to the constructors of
+  `Snak`, `PropertyValueSnak`, `PropertySomeValueSnak` and `PropertyNoValueSnak`,
+  as well as a `getHash()` function to the `Snak` class.
+
 ### 3.0.1 (2016-09-09)
 
 * Fix an issue with MediaWiki loading (init.php)

--- a/src/PropertyNoValueSnak.js
+++ b/src/PropertyNoValueSnak.js
@@ -14,6 +14,7 @@ var PARENT = wb.datamodel.Snak;
  * @constructor
  *
  * @param {string} propertyId
+ * @param {string|null} [hash=null]
  */
 var SELF
 	= wb.datamodel.PropertyNoValueSnak

--- a/src/PropertySomeValueSnak.js
+++ b/src/PropertySomeValueSnak.js
@@ -14,6 +14,7 @@ var PARENT = wb.datamodel.Snak;
  * @constructor
  *
  * @param {string} propertyId
+ * @param {string|null} [hash=null]
  */
 var SELF
 	= wb.datamodel.PropertySomeValueSnak

--- a/src/PropertyValueSnak.js
+++ b/src/PropertyValueSnak.js
@@ -15,17 +15,18 @@ var PARENT = wb.datamodel.Snak;
  *
  * @param {string} propertyId
  * @param {dataValues.DataValue} value
+ * @param {string|null} [hash=null]
  *
  * @throws {Error} value is not a dataValues.DataValue instance.
  */
 var SELF = wb.datamodel.PropertyValueSnak = util.inherit(
 	'WbDataModelPropertyValueSnak',
 	PARENT,
-	function( propertyId, value ) {
+	function( propertyId, value, hash ) {
 		if( !( value instanceof dv.DataValue ) ) {
 			throw new Error( 'The value has to be an instance of dataValues.DataValue' );
 		}
-		PARENT.call( this, propertyId );
+		PARENT.call( this, propertyId, hash );
 		this._value = value;
 	},
 {

--- a/src/Snak.js
+++ b/src/Snak.js
@@ -12,17 +12,19 @@
  * @constructor
  *
  * @param {string} propertyId
+ * @param {string|null} [hash=null]
  *
  * @throws {Error} when trying to instantiate an abstract Snak object.
  * @throws {Error} when the property id is omitted.
  */
-var SELF = wb.datamodel.Snak = function WbDataModelSnak( propertyId ) {
+var SELF = wb.datamodel.Snak = function WbDataModelSnak( propertyId, hash ) {
 	if( !this.constructor.TYPE ) {
 		throw new Error( 'Can not create abstract Snak of no specific type' );
 	} else if( !propertyId ) {
 		throw new Error( 'Property ID is required for constructing new Snak' );
 	}
 	this._propertyId = propertyId;
+	this._hash = hash || null;
 };
 
 /**
@@ -43,6 +45,12 @@ $.extend( SELF.prototype, {
 	_propertyId: null,
 
 	/**
+	 * @property {string|null}
+	 * @private
+	 */
+	_hash: null,
+
+	/**
 	 * Returns the Snak type.
 	 *
 	 * @return {string}
@@ -58,6 +66,17 @@ $.extend( SELF.prototype, {
 	 */
 	getPropertyId: function() {
 		return this._propertyId;
+	},
+
+	/**
+	 * Returns the hash of this Snak.
+	 * Can be null if this Snak was constructed client-side,
+	 * since hashes can only be computed server-side.
+	 *
+	 * @return {string|null}
+	 */
+	getHash: function() {
+		return this._hash;
 	},
 
 	/**

--- a/tests/Snak.tests.js
+++ b/tests/Snak.tests.js
@@ -8,11 +8,11 @@
 QUnit.module( 'wikibase.datamodel.Snak' );
 
 var testSets = [
-	[wb.datamodel.PropertyNoValueSnak, ['P1']],
-	[wb.datamodel.PropertyNoValueSnak, ['P2']],
-	[wb.datamodel.PropertySomeValueSnak, ['P1']],
-	[wb.datamodel.PropertyValueSnak, ['P1', new dv.StringValue( 'test' )]],
-	[wb.datamodel.PropertyValueSnak, ['P2', new dv.StringValue( 'test' )]]
+	[wb.datamodel.PropertyNoValueSnak, ['P1', undefined]],
+	[wb.datamodel.PropertyNoValueSnak, ['P2', 'hash']],
+	[wb.datamodel.PropertySomeValueSnak, ['P1', 'hash']],
+	[wb.datamodel.PropertyValueSnak, ['P1', new dv.StringValue( 'test' ), undefined]],
+	[wb.datamodel.PropertyValueSnak, ['P2', new dv.StringValue( 'test' ), 'hash']]
 ];
 
 /**
@@ -21,11 +21,11 @@ var testSets = [
  * @return {wikibase.datamodel.Snak}
  */
 function constructSnak( SnakConstructor, params ) {
-	return new SnakConstructor( params[0], params[1] );
+	return new SnakConstructor( params[0], params[1], params[2] );
 }
 
 QUnit.test( 'Constructor', function( assert ) {
-	assert.expect( 15 );
+	assert.expect( 20 );
 
 	for( var i = 0; i < testSets.length; i++ ) {
 		var SnakConstructor = testSets[i][0],
@@ -47,6 +47,12 @@ QUnit.test( 'Constructor', function( assert ) {
 			snak.getType(),
 			SnakConstructor.TYPE,
 			'Test set #' + i + ': Snak type "' + snak.getType() + '" was set correctly.'
+		);
+
+		assert.strictEqual(
+			snak.getHash(),
+			snakParams[snakParams.length - 1] || null,
+			'Test set #' + i + ': Snak hash was set correctly.'
 		);
 	}
 } );


### PR DESCRIPTION
The `Snak` class gains a `_hash` field and `getHash()` getter function, and its constructors get a new, optional `hash` parameter.