### PR TITLE
Release 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ at the heart of the [Wikibase software](http://wikiba.se/).
 
 ## Release notes
 
-### 4.0.0 (dev)
+### 4.0.0 (2017-10-09)
 
 * Made the library a pure JavaScript library.
 * Removed MediaWiki ResourceLoader module definitions.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ at the heart of the [Wikibase software](http://wikiba.se/).
 ### 4.0.0 (2017-10-09)
 
 * Made the library a pure JavaScript library.
+* Removed MediaWiki extension registration.
 * Removed MediaWiki ResourceLoader module definitions.
-* Raised DataValues JS library version requirement to 0.10.0.
+* Removed WIKIBASE_DATAMODEL_JAVASCRIPT_VERSION constant.
+* Raised DataValues JavaScript library version requirement to 0.10.0.
 * Removed all Claim collections:
   * Removed `ClaimGroup`
   * Removed `ClaimGroupSet`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wikibase-data-model",
   "description": "Wikibase datamodel implementation in JavaScript",
+  "version": "4.0.0",
   "directories": {
     "lib": "src",
     "test": "tests"


### PR DESCRIPTION
Needed for https://phabricator.wikimedia.org/T177476. Blocking https://github.com/wmde/WikibaseSerializationJavaScript/pull/47.

Note this contains commits from https://github.com/wmde/WikibaseDataModelJavaScript/pull/81 which should be merged first. The only relevant commit here is https://github.com/wmde/WikibaseDataModelJavaScript/commit/dc44cffc715621bb35590f11b7e6f3da136642df.