### PR TITLE
Use Daniel Werners preferred email address

### DIFF
--- a/src/Claim.js
+++ b/src/Claim.js
@@ -6,7 +6,7 @@
  * @class wikibase.datamodel.Claim
  * @since 0.3
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  *

--- a/src/PropertyNoValueSnak.js
+++ b/src/PropertyNoValueSnak.js
@@ -9,7 +9,7 @@ var PARENT = wb.datamodel.Snak;
  * @extends wikibase.datamodel.Snak
  * @since 0.3
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  *

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -9,7 +9,7 @@
  * @class wikibase.datamodel.Reference
  * @since 0.3
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  *
  * @constructor

--- a/src/Snak.js
+++ b/src/Snak.js
@@ -7,7 +7,7 @@
  * @abstract
  * @since 0.3
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  *
  * @constructor
  *

--- a/tests/Reference.tests.js
+++ b/tests/Reference.tests.js
@@ -1,6 +1,6 @@
 /**
  * @license GPL-2.0+
- * @author Daniel Werner < daniel.werner@wikimedia.de >
+ * @author Daniel Werner < daniel.a.r.werner@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  */
 


### PR DESCRIPTION
I contacted Daniel Werner and asked him which email address he prefers.

I had two reasons to touch this:
* Daniels wikimedia.de email does not exist any more.
* He used so many different @author tags and I wanted to unify them.