### PR TITLE
Introduce FingerprintableEntity in a backwards compatible way

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ the corresponding serializer, and send back to the API.
 
 ## Release notes
 
+### 4.1.0 (2018-06-25)
+
+* Added new FingerprintableEntity class
+ * Make Item and Property inherit from it 
+
 ### 4.0.0 (2017-10-09)
 
 * Made the library a pure JavaScript library.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wikibase-data-model",
   "description": "JavaScript implementation of the basic Wikibase DataModel entity types and components they are made of",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "directories": {
     "lib": "src",
     "test": "tests"

--- a/src/FingerprintableEntity.js
+++ b/src/FingerprintableEntity.js
@@ -1,0 +1,45 @@
+( function( wb, $ ) {
+	'use strict';
+
+var PARENT = wb.datamodel.Entity;
+
+/**
+* Abstract FingerprintableEntity class featuring an id and a fingerprint.
+* @class wikibase.datamodel.FingerprintableEntity
+* @abstract
+* @since 4.1.0
+* @license GPL-2.0+
+* @author T. Arrow < thomas.arrow_ext@wikimedia.de >
+*
+* @constructor
+*
+* @throws {Error} when trying to instantiate since FingerprintableEntity is abstract.
+*/
+
+var SELF = wb.datamodel.FingerprintableEntity = util.inherit(
+	'WbDataModelFingerprintableEntity',
+	PARENT,
+	{
+		/**
+		 * @property {wikibase.datamodel.Fingerprint}
+		 * @private
+		 */
+		_fingerprint: null,
+
+		/**
+		 * @return {wikibase.datamodel.Fingerprint}
+		 */
+		getFingerprint: function() {
+			return this._fingerprint;
+		},
+
+		/**
+		 * @param {wikibase.datamodel.Fingerprint} fingerprint
+		 */
+		setFingerprint: function( fingerprint ) {
+			this._fingerprint = fingerprint;
+		}
+	}
+);
+
+}( wikibase, jQuery ) );

--- a/src/Item.js
+++ b/src/Item.js
@@ -1,12 +1,12 @@
 ( function( wb, util ) {
 	'use strict';
 
-var PARENT = wb.datamodel.Entity;
+var PARENT = wb.datamodel.FingerprintableEntity;
 
 /**
  * Entity derivative featuring statements and site links.
  * @class wikibase.datamodel.Item
- * @extends wikibase.datamodel.Entity
+ * @extends wikibase.datamodel.FingerprintableEntity
  * @since 1.0
  * @license GPL-2.0+
  * @author H. Snater < mediawiki@snater.com >

--- a/src/Property.js
+++ b/src/Property.js
@@ -1,12 +1,12 @@
 ( function( wb, util ) {
 	'use strict';
 
-var PARENT = wb.datamodel.Entity;
+var PARENT = wb.datamodel.FingerprintableEntity;
 
 /**
  * Entity derivative featuring a data type and statements.
  * @class wikibase.datamodel.Property
- * @extends wikibase.datamodel.Entity
+ * @extends wikibase.datamodel.FingerprintableEntity
  * @since 1.0
  * @license GPL-2.0+
  * @author H. Snater < mediawiki@snater.com >


### PR DESCRIPTION
Summary:
Not all entities must have fingerprints e.g. Lexemes.

This commit starts the process of being able to remove fingerprints from Entity.

[Bug: T197085](http://phabricator.wikimedia.org/T197085)