### PR TITLE
Update eslint to be compatible with Wikibase .eslintrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "wikibase-data-values": "^0.10.0"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
+    "eslint": "^4.19.1",
     "eslint-config-wikimedia": "0.4.0",
     "karma": "^1.7.0",
     "karma-cli": "^1.0.1",


### PR DESCRIPTION
Running eslint from `extensions/Wikibase/view/lib/wikibase-data-model` fails due to the eslint versions being out sync.

```
> wikibase-data-model@4.0.0 eslint extensions/Wikibase/view/lib/wikibase-data-model
> eslint .

extensions/Wikibase/.eslintrc.json:
	Configuration for rule "indent" is invalid:
	Value "off" is the wrong type.

Error: extensions/Wikibase/.eslintrc.json:
	Configuration for rule "indent" is invalid:
	Value "off" is the wrong type.
```