### PR TITLE
Add karma-webpack for `require` in tests/tested files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,11 @@
 	"extends": "wikimedia",
 	"env": {
 		"browser": true,
-		"jquery": true
+		"jquery": true,
+		"commonjs": true
 	},
 	"globals": {
 		"dataValues": false,
-		"module": "false",
 		"util": false,
 		"wikibase": false
 	},

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,13 @@ module.exports = function ( config ) {
 		],
 		port: 9876,
 
+		preprocessors: {
+			'src/**/*.js': [ 'webpack' ],
+			'tests/**/*.tests.js': [ 'webpack' ]
+		},
+
+		webpack: { mode: 'development' },
+
 		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
 		logLevel: config.LOG_INFO,
 		browsers: [ 'PhantomJS' ]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "karma-cli": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-qunit": "^1.2.1",
-    "qunitjs": "^2.3.2"
+    "karma-webpack": "^4.0.2",
+    "qunitjs": "^2.3.2",
+    "webpack": "^4.41.0"
   },
   "scripts": {
     "test": "npm run eslint && npm run run-tests",


### PR DESCRIPTION
MediaWiki uses the CommonJS syntax to load packageFiles* through
resource loader. Since tests in this repo are not run via the usual
resource loader + qunit runner, we can use webpack to enable support for
CommonJS module syntax.