### PR TITLE
Prevent passing invalid package file paths to `require`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
 	"extends": "wikimedia",
+	"plugins": [
+		"resource-loader"
+	],
 	"env": {
 		"browser": true,
 		"jquery": true,
@@ -10,6 +13,7 @@
 		"util": false
 	},
 	"rules": {
+		"resource-loader/valid-package-file-require": "error",
 		"computed-property-spacing": "off",
 		"indent": "off",
 		"keyword-spacing": "off",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-wikimedia": "0.4.0",
+    "eslint-plugin-resource-loader": "wmde/eslint-plugin-resource-loader#b84d53f22794bb15b98f611b541fe4d32e153720",
     "karma": "^1.7.0",
     "karma-cli": "^1.0.1",
     "karma-phantomjs-launcher": "^1.0.4",


### PR DESCRIPTION
Proof of concept with some handcrafted "mistakes" to show that they're caught. The eslint rule repo should obviously move and get reviewed. I'm also not sure if a custom eslint rule is actually the best way to go about it.