### PR TITLE
Make travis run on node14 instead of 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
 - 8
 - 12
-- node
+- 14
 
 sudo: false
 


### PR DESCRIPTION
It's broken on node 16

https://app.travis-ci.com/github/wmde/WikibaseDataModelJavaScript/builds/232341624