### PR TITLE
Run tests on modern node js versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [8, 12, 14]
+                node-version: ['20.x', '22.x', '23.x']
 
         steps:
             - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "wikibase-data-values": "^0.10.0"
   },
   "devDependencies": {
-    "eslint": "^4.19.1",
+    "eslint": "^5.16.0",
     "eslint-config-wikimedia": "0.4.0",
     "eslint-plugin-mediawiki": "^0.2.1",
     "karma": "^1.7.0",


### PR DESCRIPTION
`eslint` major version bumped because the dependencies wouldn't install: https://github.com/wmde/WikibaseDataModelJavaScript/actions/runs/12698312127/job/35396519349